### PR TITLE
plugin_i2c_sensors: Add missing limits header

### DIFF
--- a/plugin_i2c_sensors.c
+++ b/plugin_i2c_sensors.c
@@ -68,6 +68,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <dirent.h>
+#include <limits.h>
 
 #include "debug.h"
 #include "plugin.h"


### PR DESCRIPTION
Needed for PATH_MAX.

Failed to compile you know where.